### PR TITLE
Add error message if IR declaration not found

### DIFF
--- a/ir/src/main/kotlin/app/softwork/kobol/ir/toIRTree.kt
+++ b/ir/src/main/kotlin/app/softwork/kobol/ir/toIRTree.kt
@@ -395,7 +395,7 @@ private fun List<Types.Type>.declaration(target: CobolFIRTree.DataTree.WorkingSt
 
         else -> null
     }
-}.single()
+}.singleOrNull() ?: error("${target.name} of ${target.recordName} not found}")
 
 private fun CobolFIRTree.ProcedureTree.Statement.toIR(
     types: List<Types.Type>,


### PR DESCRIPTION
Ideally, it should work without an error message at all.