### PR TITLE
Revert "CI: Use merge groups"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,6 @@ on:
     branches: [ main ]
   push:
     branches: [ main ]
-  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
Reverts hfhbd/kobol#527

Reason: Not supported in public user repos 