### PR TITLE
Builder: Add addAll

### DIFF
--- a/fir/src/main/kotlin/app/softwork/kobol/Builder.kt
+++ b/fir/src/main/kotlin/app/softwork/kobol/Builder.kt
@@ -5,7 +5,7 @@ package app.softwork.kobol
 @JvmInline
 public value class Builder<T> (private val list: MutableList<T> = mutableListOf()) : MutableList<T> by list {
     public inline operator fun T.unaryPlus(): Boolean = add(this)
-    //public inline operator fun List<T>.unaryPlus(): Boolean = addAll(this)
+    public inline operator fun List<T>.unaryPlus(): Boolean = addAll(this)
 }
 
 public inline fun <T> build(builder: Builder<T>.() -> Unit): MutableList<T> = Builder<T>().apply(builder).toMutableList()


### PR DESCRIPTION
Fixed in 1.8.20: https://youtrack.jetbrains.com/issue/KT-54950/NoSuchMethodError-on-calling-addAll-on-inline-class-implementing-mutable-list